### PR TITLE
Extended Sysfs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 11)
 
 # Detect if the project is being build within a project or standalone.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ message(STATUS "Fetching static dependancies")
 FetchContent_Declare(
   merase
   GIT_REPOSITORY https://github.com/ztnel/merase
-  GIT_TAG v0.1.4
+  GIT_TAG v0.1.5
 )
 FetchContent_MakeAvailable(merase)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD 11)
 
 # Detect if the project is being build within a project or standalone.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,7 +11,7 @@ message(STATUS "Fetching static dependancies")
 FetchContent_Declare(
   merase
   GIT_REPOSITORY https://github.com/ztnel/merase
-  GIT_TAG v0.1.4
+  GIT_TAG v0.1.5
 )
 FetchContent_MakeAvailable(merase)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,17 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Add merase library
+include(FetchContent)
+message(STATUS "Fetching static dependancies")
+FetchContent_Declare(
+  merase
+  GIT_REPOSITORY https://github.com/ztnel/merase
+  GIT_TAG v0.1.4
+)
+FetchContent_MakeAvailable(merase)
+
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_BINARY_DIR}/gpio)
-include_directories(${GPIO_INCLUDES})
+include_directories(${GPIO_INCLUDES} ${MERASE_INCLUDE})
 add_subdirectory(pwm)
+add_subdirectory(sysfs)

--- a/examples/pwm/main.c
+++ b/examples/pwm/main.c
@@ -50,19 +50,15 @@ void usage() {
 pwm_code set_pulse(uint64_t period, uint8_t duty) {
   pwm_code status;
   if (duty > 100) {
-    error("Invalid argument for duty: %i", duty);
     return PWM_ARG_ERROR;
   }
   uint64_t _duty = period * (int)duty/100;
-  trace("Computed duty: %lld", _duty);
   status = set_period(period);
   if (status != 0) {
-    error("Error occurred while setting PWM period with %lld", period);
     return status;
   }
   status = set_duty(_duty);
   if (status != 0) {
-    error("Error occurred while setting PWM duty with: %lld", _duty);
     return status;
   }
   return PWM_SUCCESS;

--- a/examples/pwm/main.c
+++ b/examples/pwm/main.c
@@ -21,8 +21,8 @@ void usage();
 pwm_code set_pulse(uint64_t period, uint8_t duty);
 
 int shutdown() {
-  set_enable(false);
-  set_export(false);
+  pwm_set_enable(false);
+  pwm_set_export(false);
   return 0;
 }
 
@@ -100,16 +100,16 @@ int main(int argc, char *argv[]) {
     exit(0);
   }
   // set export
-  status = set_export(true);
+  status = pwm_set_export(true);
   if (status != 0) {
     shutdown();
   }
-  status = set_pulse(period, duty);
+  status = pwm_set_pulse(period, duty);
   if (status != 0) {
     shutdown();
   }
   // set enable
-  set_enable(true);
+  pwm_set_enable(true);
   if (status != 0) {
     shutdown();
   }

--- a/examples/pwm/main.c
+++ b/examples/pwm/main.c
@@ -99,7 +99,6 @@ int main(int argc, char *argv[]) {
     usage();
     exit(0);
   }
-  pwm_init();
   // set export
   status = set_export(true);
   if (status != 0) {

--- a/examples/sysfs/CMakeLists.txt
+++ b/examples/sysfs/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16.0)
+
+project(sysfs_driver)
+
+message(STATUS "Building Sysfs Example Driver")
+add_executable(ex-sysfs main.c)
+target_link_libraries(ex-sysfs PRIVATE gpio-static merase-static)

--- a/examples/sysfs/main.c
+++ b/examples/sysfs/main.c
@@ -70,5 +70,7 @@ int main(int argc, char *argv[]) {
   while (fgets(output, sizeof(output), fp) != NULL) {
     printf("%s", output);
   }
+  char *duty = rctl(DUTY_PATH, 8);
+  info("Duty Cycle: %s", duty);
   return 0;
 }

--- a/examples/sysfs/main.c
+++ b/examples/sysfs/main.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
   while (fgets(output, sizeof(output), fp) != NULL) {
     printf("%s", output);
   }
-  char *duty = rctl(DUTY_PATH, 8);
+  char *duty = rctl("/sys/class/pwm/pwmchip0/pwm0/duty_cycle", 8);
   info("Duty Cycle: %s", duty);
   return 0;
 }

--- a/examples/sysfs/main.c
+++ b/examples/sysfs/main.c
@@ -36,7 +36,7 @@ void usage() {
 int main(int argc, char *argv[]) {
   int c, status, errflg = 0;
   char *cmd = NULL;
-  logger_set_level(TRACE);
+  merase_set_level(TRACE);
   while ((c = getopt(argc, argv, OPTSTR)) != -1) {
     switch (c) {
       case 'h':

--- a/examples/sysfs/main.c
+++ b/examples/sysfs/main.c
@@ -65,6 +65,10 @@ int main(int argc, char *argv[]) {
     usage();
     exit(0);
   }
-  printf("%s", exec_linux_cmd(cmd));
+  char output[1024];
+  FILE *fp = exec_linux_cmd(cmd);
+  while (fgets(output, sizeof(output), fp) != NULL) {
+    printf("%s", output);
+  }
   return 0;
 }

--- a/examples/sysfs/main.c
+++ b/examples/sysfs/main.c
@@ -1,0 +1,70 @@
+/**
+ * @file main.c
+ * @author your name (you@domain.com)
+ * @brief Example usage of sysfs driver
+ * @version 0.1
+ * @date 2022-02
+ * 
+ * @copyright Copyright © 2022 Christian Sargusingh
+ * 
+ */
+#include <sysfs.h>
+#include <merase.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#define OPTSTR ":hc:"
+
+int shutdown();
+void usage();
+
+void usage() {
+  printf(
+    "Example Sysfs Driver.\n"
+    "Usage:\n"
+    "  ex-sysfs\n"
+    "  ex-pwm -c <cmd>\n"
+    "  ex-pwm -h\n\n"
+    "Options:\n"
+    "  -h --help      Show this screen.\n"
+    "  -c <cmd>       Execute linux command\n"
+  );
+}
+
+int main(int argc, char *argv[]) {
+  int c, status, errflg = 0;
+  char *cmd = NULL;
+  logger_set_level(TRACE);
+  while ((c = getopt(argc, argv, OPTSTR)) != -1) {
+    switch (c) {
+      case 'h':
+        usage();
+        exit(0);
+      case 'c':
+        cmd = optarg;
+        break;
+      case ':':
+        fprintf(stderr, "-%c without argument\n", optopt);
+        errflg++;
+        break;
+      case '?':
+        fprintf(stderr, "unknown argument -%c\n", optopt);
+        errflg++;
+        break;
+      default:
+        abort();
+    }
+  }
+  if (errflg) {
+    usage();
+    exit(2);
+  }
+  if (cmd == NULL) {
+    usage();
+    exit(0);
+  }
+  printf("%s", exec_linux_cmd(cmd));
+  return 0;
+}

--- a/include/errors.h
+++ b/include/errors.h
@@ -4,12 +4,13 @@
 
 #include <stdint.h>
 
-typedef int pwm_code;
+typedef int pwm_status;
 
 #define PWM_SUCCESS                 (uint8_t) 0
 #define PWM_GENERAL_ERROR           (uint8_t) 1
 #define PWM_SYSFS_WRITE_ERROR       (uint8_t) 2
-#define PWM_SYSFS_CLOSE_ERROR       (uint8_t) 3
-#define PWM_ARG_ERROR               (uint8_t) 4
+#define PWM_SYSFS_READ_ERROR        (uint8_t) 3
+#define PWM_SYSFS_CLOSE_ERROR       (uint8_t) 4
+#define PWM_ARG_ERROR               (uint8_t) 5
 
 #endif  // ERRORS_H_

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -15,10 +15,28 @@
 #include <stdbool.h>
 #include "errors.h"
 
-pwm_code set_export(bool reserve);
-pwm_code set_enable(bool enable);
-pwm_code set_duty(uint64_t duty);
-pwm_code set_period(uint64_t period);
-pwm_code set_pulse(uint64_t period, uint8_t duty);
+enum pwm_polarity {
+  NORMAL,
+  INVERSE,
+};
+
+enum pwm_channel {
+  PWM0,
+  PWM1,
+};
+
+struct pwm_iface {
+  uint8_t channel;
+  uint64_t duty;
+  uint64_t period;
+  pwm_polarity polarity;
+  pwm_channel enable;
+}; 
+
+pwm_code pwm_set_export(bool reserve);
+pwm_code pwm_set_enable(bool enable);
+pwm_code pwm_set_duty(uint64_t duty);
+pwm_code pwm_set_period(uint64_t period);
+pwm_code pwm_set_pulse(uint64_t period, uint8_t duty);
 
 #endif  // PWM_H_

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -20,6 +20,5 @@ pwm_code set_enable(bool enable);
 pwm_code set_duty(uint64_t duty);
 pwm_code set_period(uint64_t period);
 pwm_code set_pulse(uint64_t period, uint8_t duty);
-void pwm_init();
 
 #endif  // PWM_H_

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -29,14 +29,15 @@ struct pwm_iface {
   uint8_t channel;
   uint64_t duty;
   uint64_t period;
-  pwm_polarity polarity;
-  pwm_channel enable;
+  enum pwm_polarity polarity;
+  enum pwm_channel enable;
 }; 
 
-pwm_code pwm_set_export(bool reserve);
-pwm_code pwm_set_enable(bool enable);
-pwm_code pwm_set_duty(uint64_t duty);
-pwm_code pwm_set_period(uint64_t period);
-pwm_code pwm_set_pulse(uint64_t period, uint8_t duty);
+void pwm_init();
+pwm_status pwm_set_export(bool reserve);
+pwm_status pwm_set_enable(bool enable);
+pwm_status pwm_set_duty(uint64_t duty);
+pwm_status pwm_set_period(uint64_t period);
+pwm_status pwm_set_pulse(uint64_t period, uint8_t duty);
 
 #endif  // PWM_H_

--- a/include/sysfs.h
+++ b/include/sysfs.h
@@ -16,14 +16,6 @@
 #include <stdio.h>
 #include "errors.h"
 
-// constant path definitions
-static const char EXPORT_PATH[] = "/sys/class/pwm/pwmchip0/export";
-static const char UNEXPORT_PATH[] = "/sys/class/pwm/pwmchip0/unexport";
-static const char PERIOD_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/period";
-static const char DUTY_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/duty_cycle";
-static const char ENABLE_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/enable";
-static const char POLARITY[] = "/sys/class/pwm/pwmchip0/pwm0/polarity";
-
 
 char *rctl(const char *path, size_t buf_size);
 int wctl(const char *path, const char *buf, size_t buf_size);

--- a/include/sysfs.h
+++ b/include/sysfs.h
@@ -24,7 +24,7 @@ static const char DUTY_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/duty_cycle";
 static const char ENABLE_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/enable";
 
 
-char *rctl(const char *path);
+char *rctl(const char *path, size_t buf_size);
 int wctl(const char *path, const char *buf, size_t buf_size);
 char *int64_to_str(uint64_t value, size_t *size);
 void free_buffer(char *buf);

--- a/include/sysfs.h
+++ b/include/sysfs.h
@@ -22,6 +22,7 @@ static const char UNEXPORT_PATH[] = "/sys/class/pwm/pwmchip0/unexport";
 static const char PERIOD_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/period";
 static const char DUTY_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/duty_cycle";
 static const char ENABLE_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/enable";
+static const char POLARITY[] = "/sys/class/pwm/pwmchip0/pwm0/polarity";
 
 
 char *rctl(const char *path, size_t buf_size);

--- a/include/sysfs.h
+++ b/include/sysfs.h
@@ -24,7 +24,8 @@ static const char DUTY_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/duty_cycle";
 static const char ENABLE_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/enable";
 
 
-int ioctl(const char *path, const char *buf, size_t buf_size);
+char *rctl(const char *path);
+int wctl(const char *path, const char *buf, size_t buf_size);
 char *int64_to_str(uint64_t value, size_t *size);
 void free_buffer(char *buf);
 FILE *exec_linux_cmd(char *cmd);

--- a/include/sysfs.h
+++ b/include/sysfs.h
@@ -24,8 +24,9 @@ static const char DUTY_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/duty_cycle";
 static const char ENABLE_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/enable";
 
 
-int ioctl(const char* path, const char* buf, size_t buf_size);
-char* int64_to_str(uint64_t value, size_t *size);
-void free_buffer(char* buf);
+int ioctl(const char *path, const char *buf, size_t buf_size);
+char *int64_to_str(uint64_t value, size_t *size);
+void free_buffer(char *buf);
+FILE *exec_linux_cmd(char *cmd);
 
 #endif  // SYSFS_H_

--- a/src/pwm.c
+++ b/src/pwm.c
@@ -14,48 +14,82 @@
 #include <stdbool.h>
 #include <string.h>
 #include <merase.h>
+#include <pthread.h>
 #include "errors.h"
 #include "pwm.h"
 #include "sysfs.h"
 
-static pwm_iface pwm = {
+
+// constant path definitions
+static const char _EXPORT_PATH[] = "/sys/class/pwm/pwmchip0/export";
+static const char _UNEXPORT_PATH[] = "/sys/class/pwm/pwmchip0/unexport";
+static const char _PERIOD_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/period";
+static const char _DUTY_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/duty_cycle";
+static const char _ENABLE_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/enable";
+static const char _POLARITY_PATH[] = "/sys/class/pwm/pwmchip0/pwm0/polarity";
+
+static struct pwm_iface pwm = {
+  .channel=PWM0,
+  .duty=0,
+  .period=0,
+  .polarity=NORMAL,
+  .enable=false
 };
 
+static void _initialize_state();
+
+/**
+ * @brief Initialize the pwm interface and populate parameters
+ * 
+ */
 void pwm_init() {
   pwm_set_export(true);
-  pwm_read_state();
+  _initialize_state();
+  info("pwm state initialized");
 }
 
-pwm_code pwm_read_state() {
-  char *buf = rctl(DUTY_PATH, 8);
-  pwm->duty = atoi(buf);
-  free_buffer(buf);
-  char *buf = rctl(PERIOD_PATH, 8);
-  pwm->period = atoi(buf);
-  free_buffer(buf);
-  char *buf = rctl(, 8);
-  if (strcmp(buf, "normal") == 0)
-    pwm->polarity = NORMAL;
-  else
-    pwm->polarity = INVERSE;
-  free_buffer(buf);
+/**
+ * @brief Read pwm state variables and populate local struct
+ * 
+ */
+static void _initialize_state() {
+  char *buf;
 
+  buf = rctl(_DUTY_PATH, 8);
+  if (buf != NULL)
+    pwm.duty = atoll(buf);
+    free_buffer(buf);
+
+  buf = rctl(_PERIOD_PATH, 8);
+  if (buf != NULL)
+    pwm.period = atoll(buf);
+    free_buffer(buf);
+
+  buf = rctl(_ENABLE_PATH, 5);
+  if (buf != NULL)
+    pwm.enable = (strcmp(buf, "1") == 0) ? true : false;
+    free_buffer(buf);
+
+  buf = rctl(_POLARITY_PATH, 7);
+  if (buf != NULL)
+    pwm.polarity = (strcmp(buf, "normal") == 0) ? NORMAL : INVERSE;
+    free_buffer(buf);
 }
 
 /**
  * @brief Reserve or close access to pwmchip0
  * 
  * @param reserve reservation flag 
- * @return pwm_code 
+ * @return pwm_status 
  */
-pwm_code pwm_set_export(bool reserve) {
-  pwm_code status;
+pwm_status pwm_set_export(bool reserve) {
+  pwm_status status;
   size_t size = sizeof(uint8_t);
   if (reserve) {
-    status = wctl(EXPORT_PATH, "1", size);
+    status = wctl(_EXPORT_PATH, "1", size);
     trace("pwm export returned status: %d", status);
   } else {
-    status = wctl(UNEXPORT_PATH, "1", size);
+    status = wctl(_UNEXPORT_PATH, "1", size);
     trace("pwm unexport returned status: %d", status);
   }
   return status;
@@ -65,16 +99,16 @@ pwm_code pwm_set_export(bool reserve) {
  * @brief Enable/Disable pwm channel
  * 
  * @param enable flag for enable/disable
- * @return pwm_code 
+ * @return pwm_status 
  */
-pwm_code pwm_set_enable(bool enable) {
-  pwm_code status;
+pwm_status pwm_set_enable(bool enable) {
+  pwm_status status;
   size_t size = sizeof(uint8_t);
   if (enable) {
-    status = wctl(ENABLE_PATH, "1", size);
+    status = wctl(_ENABLE_PATH, "1", size);
     trace("Set pwm enable returned status: %d", status);
   } else {
-    status = wctl(ENABLE_PATH, "0", size);
+    status = wctl(_ENABLE_PATH, "0", size);
     trace("Set pwm disable returned status: %d", status);
   }
   return status;
@@ -84,13 +118,13 @@ pwm_code pwm_set_enable(bool enable) {
  * @brief Set the duty cycle of the pwm waveform in ns
  * 
  * @param duty positive pulse width in ns
- * @return pwm_code 
+ * @return pwm_status 
  */
-pwm_code pwm_set_duty(uint64_t duty) {
+pwm_status pwm_set_duty(uint64_t duty) {
   size_t size;
   char *buf = int64_to_str(duty, &size);
   info("Buffer: %s Size: %d\n", buf, size);
-  pwm_code status = wctl(DUTY_PATH, buf, size);
+  pwm_status status = wctl(_DUTY_PATH, buf, size);
   free_buffer(buf);
   trace("Set pwm duty returned status: %d", status);
   return status;
@@ -100,13 +134,13 @@ pwm_code pwm_set_duty(uint64_t duty) {
  * @brief Set the waveform pulse period in ns 
  * 
  * @param period pulse period in nanoseconds
- * @return pwm_code 
+ * @return pwm_status 
  */
-pwm_code pwm_set_period(uint64_t period) {
+pwm_status pwm_set_period(uint64_t period) {
   size_t size;
   char *buf = int64_to_str(period, &size);
   info("Buffer: %s Size: %d\n", buf, size);
-  pwm_code status = wctl(PERIOD_PATH, buf, size);
+  pwm_status status = wctl(_PERIOD_PATH, buf, size);
   free_buffer(buf);
   trace("Set pwm period returned status: %d", status);
   return status;

--- a/src/pwm.c
+++ b/src/pwm.c
@@ -56,24 +56,28 @@ static void _initialize_state() {
   char *buf;
 
   buf = rctl(_DUTY_PATH, 8);
-  if (buf != NULL)
+  if (buf != NULL) {
     pwm.duty = atoll(buf);
     free_buffer(buf);
+  }
 
   buf = rctl(_PERIOD_PATH, 8);
-  if (buf != NULL)
+  if (buf != NULL) {
     pwm.period = atoll(buf);
     free_buffer(buf);
+  }
 
   buf = rctl(_ENABLE_PATH, 5);
-  if (buf != NULL)
+  if (buf != NULL) {
     pwm.enable = (strcmp(buf, "1") == 0) ? true : false;
     free_buffer(buf);
+  }
 
   buf = rctl(_POLARITY_PATH, 7);
-  if (buf != NULL)
+  if (buf != NULL) {
     pwm.polarity = (strcmp(buf, "normal") == 0) ? NORMAL : INVERSE;
     free_buffer(buf);
+  }
 }
 
 /**

--- a/src/pwm.c
+++ b/src/pwm.c
@@ -18,6 +18,29 @@
 #include "pwm.h"
 #include "sysfs.h"
 
+static pwm_iface pwm = {
+};
+
+void pwm_init() {
+  pwm_set_export(true);
+  pwm_read_state();
+}
+
+pwm_code pwm_read_state() {
+  char *buf = rctl(DUTY_PATH, 8);
+  pwm->duty = atoi(buf);
+  free_buffer(buf);
+  char *buf = rctl(PERIOD_PATH, 8);
+  pwm->period = atoi(buf);
+  free_buffer(buf);
+  char *buf = rctl(, 8);
+  if (strcmp(buf, "normal") == 0)
+    pwm->polarity = NORMAL;
+  else
+    pwm->polarity = INVERSE;
+  free_buffer(buf);
+
+}
 
 /**
  * @brief Reserve or close access to pwmchip0
@@ -25,7 +48,7 @@
  * @param reserve reservation flag 
  * @return pwm_code 
  */
-pwm_code set_export(bool reserve) {
+pwm_code pwm_set_export(bool reserve) {
   pwm_code status;
   size_t size = sizeof(uint8_t);
   if (reserve) {
@@ -44,7 +67,7 @@ pwm_code set_export(bool reserve) {
  * @param enable flag for enable/disable
  * @return pwm_code 
  */
-pwm_code set_enable(bool enable) {
+pwm_code pwm_set_enable(bool enable) {
   pwm_code status;
   size_t size = sizeof(uint8_t);
   if (enable) {
@@ -63,7 +86,7 @@ pwm_code set_enable(bool enable) {
  * @param duty positive pulse width in ns
  * @return pwm_code 
  */
-pwm_code set_duty(uint64_t duty) {
+pwm_code pwm_set_duty(uint64_t duty) {
   size_t size;
   char *buf = int64_to_str(duty, &size);
   info("Buffer: %s Size: %d\n", buf, size);
@@ -79,7 +102,7 @@ pwm_code set_duty(uint64_t duty) {
  * @param period pulse period in nanoseconds
  * @return pwm_code 
  */
-pwm_code set_period(uint64_t period) {
+pwm_code pwm_set_period(uint64_t period) {
   size_t size;
   char *buf = int64_to_str(period, &size);
   info("Buffer: %s Size: %d\n", buf, size);

--- a/src/pwm.c
+++ b/src/pwm.c
@@ -88,11 +88,3 @@ pwm_code set_period(uint64_t period) {
   trace("Set pwm period returned status: %d", status);
   return status;
 }
-
-/**
- * @brief Initialize the pwm api
- * 
- */
-void pwm_init() {
-  logger_set_level(TRACE);
-}

--- a/src/pwm.c
+++ b/src/pwm.c
@@ -29,10 +29,10 @@ pwm_code set_export(bool reserve) {
   pwm_code status;
   size_t size = sizeof(uint8_t);
   if (reserve) {
-    status = ioctl(EXPORT_PATH, "1", size);
+    status = wctl(EXPORT_PATH, "1", size);
     trace("pwm export returned status: %d", status);
   } else {
-    status = ioctl(UNEXPORT_PATH, "1", size);
+    status = wctl(UNEXPORT_PATH, "1", size);
     trace("pwm unexport returned status: %d", status);
   }
   return status;
@@ -48,10 +48,10 @@ pwm_code set_enable(bool enable) {
   pwm_code status;
   size_t size = sizeof(uint8_t);
   if (enable) {
-    status = ioctl(ENABLE_PATH, "1", size);
+    status = wctl(ENABLE_PATH, "1", size);
     trace("Set pwm enable returned status: %d", status);
   } else {
-    status = ioctl(ENABLE_PATH, "0", size);
+    status = wctl(ENABLE_PATH, "0", size);
     trace("Set pwm disable returned status: %d", status);
   }
   return status;
@@ -67,7 +67,7 @@ pwm_code set_duty(uint64_t duty) {
   size_t size;
   char *buf = int64_to_str(duty, &size);
   info("Buffer: %s Size: %d\n", buf, size);
-  pwm_code status = ioctl(DUTY_PATH, buf, size);
+  pwm_code status = wctl(DUTY_PATH, buf, size);
   free_buffer(buf);
   trace("Set pwm duty returned status: %d", status);
   return status;
@@ -83,7 +83,7 @@ pwm_code set_period(uint64_t period) {
   size_t size;
   char *buf = int64_to_str(period, &size);
   info("Buffer: %s Size: %d\n", buf, size);
-  pwm_code status = ioctl(PERIOD_PATH, buf, size);
+  pwm_code status = wctl(PERIOD_PATH, buf, size);
   free_buffer(buf);
   trace("Set pwm period returned status: %d", status);
   return status;

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -41,7 +41,7 @@ char *rctl(const char *path, size_t size) {
     error("Error while opening %s", path);
     goto _cleanup;
   }
-  size_t sz = read(fd, buf, size);
+  ssize_t sz = read(fd, buf, size);
   info("Successful read of %d bytes: %s", sz, buf);
 
 _cleanup:
@@ -77,7 +77,8 @@ int wctl(const char *path, const char *buf, size_t buf_size) {
   write(fd, buf, buf_size);
   if (close(fd) == -1) {
     error("Error when closing file: %d", fd);
-    goto ;
+    status = 1;
+    goto _cleanup;
   }
   info("Successful write of %d bytes: %s", buf_size, buf);
   status = 0;

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -26,7 +26,7 @@
  * @param buf_size data buffer size in bytes
  * @return int 
  */
-int ioctl(const char* path, const char* buf, size_t buf_size) {
+int ioctl(const char *path, const char *buf, size_t buf_size) {
   if (path == NULL || buf == NULL || buf_size == 0) {
     error("Invalid arg");
     return 1;
@@ -50,7 +50,7 @@ int ioctl(const char* path, const char* buf, size_t buf_size) {
  * @param size size of buffer
  * @return char* 
  */
-char* int64_to_str(uint64_t value, size_t* size) {
+char *int64_to_str(uint64_t value, size_t *size) {
   // get length of string size
   int len = snprintf(NULL, 0, "%lld", value);
   // +1 allocation for null terminator '\0'
@@ -65,7 +65,23 @@ char* int64_to_str(uint64_t value, size_t* size) {
  * 
  * @param str_alloc malloc pointer for int->str conversion
  */
-void free_buffer(char* buf) {
+void free_buffer(char *buf) {
   free(buf);
   info("String buffer freed");
+}
+
+/**
+ * @brief Execute linux command and capture output
+ * 
+ * @param cmd 
+ * @return char* 
+ */
+FILE *exec_linux_cmd(char *cmd) {
+  char bufline[1024];
+  FILE *fp = popen(cmd, "r");
+  if (fp == NULL) {
+    error("Command %s failed to execute", cmd);
+    exit(EXIT_FAILURE);
+  }
+  return fp;
 }

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -61,7 +61,7 @@ int wctl(const char *path, const char *buf, size_t buf_size) {
   int status;
   if (path == NULL || buf == NULL || buf_size == 0) {
     error("Invalid argument");
-    goto _cleanup;
+    return EXIT_FAILURE;
   }
   trace("Opening path %s for write of %x with size %i", path, buf, buf_size);
   pthread_mutex_lock(&s_mtx);
@@ -69,18 +69,18 @@ int wctl(const char *path, const char *buf, size_t buf_size) {
   int fd = open(path, O_WRONLY);
   if (fd < 0) {
     error("Error while opening %s", path);
-    status = 1;
+    status = EXIT_FAILURE;
     goto _cleanup;
   }
   // write buffer
   write(fd, buf, buf_size);
   if (close(fd) == -1) {
     error("Error when closing file: %d", fd);
-    status = 1;
+    status = EXIT_FAILURE;
     goto _cleanup;
   }
   info("Successful write of %d bytes: %s", buf_size, buf);
-  status = 0;
+  status = EXIT_SUCCESS;
 
 _cleanup:
   pthread_mutex_unlock(&s_mtx);

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -29,11 +29,11 @@ static pthread_mutex_t s_mtx;
  * @return char* 
  */
 char *rctl(const char *path, size_t size) {
-  char *buf = (char *)malloc(size);
   if (path == NULL) {
     error("Path cannot be null");
-    goto _return;
+    return NULL;
   }
+  char *buf = (char *)malloc(size);
   trace("Opening path %s for read", path);
   pthread_mutex_lock(&s_mtx);
   int fd = open(path, O_RDONLY);
@@ -46,7 +46,6 @@ char *rctl(const char *path, size_t size) {
 
 _cleanup:
   pthread_mutex_unlock(&s_mtx);
-_return:
   return buf;
 }
 


### PR DESCRIPTION
# Description
Adding extended thread safe support to sysfs control functions. Adding sysfs read control to continually validate pwm state.

## Resolutions
 - [x] Add linux command dispatch function
 - [x] Split error definitions for `sysfs` and `pwm`
 - [x] Split `ioctl` to read and write control functions with mutex locking
 - [x] Update unittests
 - [x] Implement PWM struct and initialization interface

